### PR TITLE
Fixed player cooldown resetting when leaving and rejoining the server

### DIFF
--- a/plugin/src/main/java/com/iridium/iridiumcore/CooldownProvider.java
+++ b/plugin/src/main/java/com/iridium/iridiumcore/CooldownProvider.java
@@ -1,8 +1,11 @@
 package com.iridium.iridiumcore;
 
+import org.bukkit.entity.Player;
+
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Provides various cooldown features.
@@ -12,6 +15,7 @@ import java.util.Map;
 public class CooldownProvider<T> {
 
     private final Map<T, Duration> cooldownTimes = new HashMap<>();
+    private final Map<UUID, Duration> cooldownTimesForPlayers = new HashMap<>();
     private final Duration duration;
 
     /**
@@ -30,6 +34,10 @@ public class CooldownProvider<T> {
      * @return True if the entity has a valid cooldown
      */
     public boolean isOnCooldown(T t) {
+        if(t instanceof Player) {
+            return cooldownTimesForPlayers.containsKey(((Player) t).getUniqueId()) && cooldownTimesForPlayers.get(((Player) t).getUniqueId()).toMillis() > System.currentTimeMillis();
+        }
+
         return cooldownTimes.containsKey(t) && cooldownTimes.get(t).toMillis() > System.currentTimeMillis();
     }
 
@@ -43,6 +51,10 @@ public class CooldownProvider<T> {
     public Duration getRemainingTime(T t) {
         if (!isOnCooldown(t)) return Duration.ZERO;
 
+        if(t instanceof Player){
+            return cooldownTimesForPlayers.get(((Player) t).getUniqueId()).minusMillis(System.currentTimeMillis());
+        }
+
         return cooldownTimes.get(t).minusMillis(System.currentTimeMillis());
     }
 
@@ -53,7 +65,11 @@ public class CooldownProvider<T> {
      * @param t The entity which should be checked
      */
     public void applyCooldown(T t) {
+        if(t instanceof Player) {
+            cooldownTimesForPlayers.put(((Player) t).getUniqueId(), duration.plusMillis(System.currentTimeMillis()));
+            return;
+        }
+
         cooldownTimes.put(t, duration.plusMillis(System.currentTimeMillis()));
     }
-
 }

--- a/plugin/src/main/java/com/iridium/iridiumcore/CooldownProvider.java
+++ b/plugin/src/main/java/com/iridium/iridiumcore/CooldownProvider.java
@@ -1,11 +1,10 @@
 package com.iridium.iridiumcore;
 
-import org.bukkit.entity.Player;
+import org.bukkit.entity.Entity;
 
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * Provides various cooldown features.
@@ -14,8 +13,7 @@ import java.util.UUID;
  */
 public class CooldownProvider<T> {
 
-    private final Map<T, Duration> cooldownTimes = new HashMap<>();
-    private final Map<UUID, Duration> cooldownTimesForPlayers = new HashMap<>();
+    private final Map<Object, Duration> cooldownTimes = new HashMap<>();
     private final Duration duration;
 
     /**
@@ -33,9 +31,9 @@ public class CooldownProvider<T> {
      * @param t The entity which should be checked
      * @return True if the entity has a valid cooldown
      */
-    public boolean isOnCooldown(T t) {
-        if(t instanceof Player) {
-            return cooldownTimesForPlayers.containsKey(((Player) t).getUniqueId()) && cooldownTimesForPlayers.get(((Player) t).getUniqueId()).toMillis() > System.currentTimeMillis();
+    public boolean isOnCooldown(Object t) {
+        if(t instanceof Entity) {
+            return isOnCooldown(((Entity) t).getEntityId());
         }
 
         return cooldownTimes.containsKey(t) && cooldownTimes.get(t).toMillis() > System.currentTimeMillis();
@@ -48,12 +46,12 @@ public class CooldownProvider<T> {
      * @param t The entity which should be checked
      * @return The duration of the cooldown, can be ZERO
      */
-    public Duration getRemainingTime(T t) {
-        if (!isOnCooldown(t)) return Duration.ZERO;
-
-        if(t instanceof Player){
-            return cooldownTimesForPlayers.get(((Player) t).getUniqueId()).minusMillis(System.currentTimeMillis());
+    public Duration getRemainingTime(Object t) {
+        if(t instanceof Entity){
+            return getRemainingTime(((Entity) t).getEntityId());
         }
+
+        if (!isOnCooldown(t)) return Duration.ZERO;
 
         return cooldownTimes.get(t).minusMillis(System.currentTimeMillis());
     }
@@ -64,9 +62,9 @@ public class CooldownProvider<T> {
      *
      * @param t The entity which should be checked
      */
-    public void applyCooldown(T t) {
-        if(t instanceof Player) {
-            cooldownTimesForPlayers.put(((Player) t).getUniqueId(), duration.plusMillis(System.currentTimeMillis()));
+    public void applyCooldown(Object t) {
+        if(t instanceof Entity){
+            applyCooldown(((Entity) t).getEntityId());
             return;
         }
 

--- a/plugin/src/main/java/com/iridium/iridiumcore/CooldownProvider.java
+++ b/plugin/src/main/java/com/iridium/iridiumcore/CooldownProvider.java
@@ -33,7 +33,7 @@ public class CooldownProvider<T> {
      */
     public boolean isOnCooldown(Object t) {
         if(t instanceof Entity) {
-            return isOnCooldown(((Entity) t).getEntityId());
+            return isOnCooldown(((Entity) t).getUniqueId());
         }
 
         return cooldownTimes.containsKey(t) && cooldownTimes.get(t).toMillis() > System.currentTimeMillis();
@@ -48,7 +48,7 @@ public class CooldownProvider<T> {
      */
     public Duration getRemainingTime(Object t) {
         if(t instanceof Entity){
-            return getRemainingTime(((Entity) t).getEntityId());
+            return getRemainingTime(((Entity) t).getUniqueId());
         }
 
         if (!isOnCooldown(t)) return Duration.ZERO;
@@ -64,7 +64,7 @@ public class CooldownProvider<T> {
      */
     public void applyCooldown(Object t) {
         if(t instanceof Entity){
-            applyCooldown(((Entity) t).getEntityId());
+            applyCooldown(((Entity) t).getUniqueId());
             return;
         }
 


### PR DESCRIPTION
Fixed player cooldown resetting when leaving and rejoining the server Because the Player class resets itself when leaving the server, players could bypass the cooldown. Now if the object is a Player, its UUID is saved