### PR TITLE
Fixed persist stack overflow

### DIFF
--- a/plugin/src/main/java/com/iridium/iridiumcore/Persist.java
+++ b/plugin/src/main/java/com/iridium/iridiumcore/Persist.java
@@ -195,8 +195,8 @@ public class Persist {
                 try {
                     if (!backupFolder.exists()) backupFolder.mkdir();
                     Files.copy(file.toPath(), backupConfigFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                    file.renameTo(new File(javaPlugin.getDataFolder(), file.getName() + "_BROKEN"));
-
+                    file.delete();
+                    load(clazz, file);
                 } catch (IOException exception) {
                     javaPlugin.getLogger().severe(
                             "Failed to move " + file + " to "


### PR DESCRIPTION
- if the config contained an invalid value, we back it up, but because we didn't delete the file, we would loop recursively to load the config with that value, which would be invalid - until the stack overflowed and killed the plugin