### PR TITLE
Updated Persist class to avoid stack overflow

### DIFF
--- a/plugin/src/main/java/com/iridium/iridiumcore/Persist.java
+++ b/plugin/src/main/java/com/iridium/iridiumcore/Persist.java
@@ -195,8 +195,8 @@ public class Persist {
                 try {
                     if (!backupFolder.exists()) backupFolder.mkdir();
                     Files.copy(file.toPath(), backupConfigFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                    file.renameTo(new File(javaPlugin.getDataFolder(), file.getName() + "_BROKEN"));
-
+                    Files.delete(file.toPath());
+                    javaPlugin.getLogger().info("Success! Backup \"" + file.getName() + "\" created, check \"" + backupFolder.getPath() + "\".");
                 } catch (IOException exception) {
                     javaPlugin.getLogger().severe(
                             "Failed to move " + file + " to "
@@ -205,10 +205,7 @@ public class Persist {
                                     + exception.getMessage());
                     Bukkit.getPluginManager().disablePlugin(javaPlugin);
                 }
-
-                javaPlugin.getLogger().info("Success! Backup \"" + file.getName() + "\" created, check \"" + backupFolder.getPath() + "\".");
                 load(clazz, file);
-
             }
         }
 


### PR DESCRIPTION
this issue happened when there was a config option that did not exist in the plugin, as we were simply reloading the config instead of clearing it and reading from default values

- removed renaming the file because we're already backing it up
- moved success message to try/catch to indicate success