### PR TITLE
Initialized instance

### DIFF
--- a/plugin/src/main/java/com/iridium/iridiumcore/IridiumCore.java
+++ b/plugin/src/main/java/com/iridium/iridiumcore/IridiumCore.java
@@ -43,6 +43,7 @@ public class IridiumCore extends JavaPlugin {
         setTesting(true);
         // Disable logging
         getLogger().setFilter(record -> false);
+        instance = this;
     }
 
     /**
@@ -51,6 +52,7 @@ public class IridiumCore extends JavaPlugin {
      */
     @Override
     public void onLoad() {
+        instance = this; // we need to override this later, but the Item.migrateData() needs this.
         // Create the data folder in order to make Jackson work
         getDataFolder().mkdir();
 

--- a/plugin/src/main/java/com/iridium/iridiumcore/IridiumCore.java
+++ b/plugin/src/main/java/com/iridium/iridiumcore/IridiumCore.java
@@ -43,7 +43,6 @@ public class IridiumCore extends JavaPlugin {
         setTesting(true);
         // Disable logging
         getLogger().setFilter(record -> false);
-        instance = this;
     }
 
     /**
@@ -52,7 +51,7 @@ public class IridiumCore extends JavaPlugin {
      */
     @Override
     public void onLoad() {
-        instance = this; // we need to override this later, but the Item.migrateData() needs this.
+        instance = this;
         // Create the data folder in order to make Jackson work
         getDataFolder().mkdir();
 
@@ -67,7 +66,6 @@ public class IridiumCore extends JavaPlugin {
      */
     @Override
     public void onEnable() {
-        instance = this;
         setupMultiVersion();
 
         if (!PaperLib.isSpigot() && !isTesting()) {


### PR DESCRIPTION
because SOMEONE forgot to initialize the instance on load, which broke Item.migrateData()